### PR TITLE
透過PNG対策ほか

### DIFF
--- a/source/chrome/content/ankpixiv.js
+++ b/source/chrome/content/ankpixiv.js
@@ -376,6 +376,8 @@ try {
           }
           return result;
         } else {
+          if ( value && ! AnkPixiv.in.manga && name == 'path.mangaIndexPage')
+            value = value.replace(/mode=manga/,'mode=medium');
           return value ? name + "\n" + indent(value) + "\n" : '';
         }
       }
@@ -1182,7 +1184,7 @@ try {
             nextButton.innerHTML = '>>';
             closeButton.innerHTML = '\xD7';
             buttonPanel.setAttribute('style', 'position: fixed !important; bottom: 0px; width: 100%; opacity: 0; z-index: 666');
-            bigImg.setAttribute('style', 'margin: 0px');
+            bigImg.setAttribute('style', 'margin: 0px; background: #FFFFFF');
             imgPanel.setAttribute('style', 'margin: 0px');
 
             [prevButton, nextButton, closeButton].forEach(function (button) {


### PR DESCRIPTION
下記２点の変更を行いました。ご検討いただければと思います。

・透過PNGの作品で、ビューアでうまく表示できない場合があったものへの対策
　※ご参考：http://www.pixiv.net/member_illust.php?mode=medium&illust_id=36748118

・イラスト形式の場合、メタテキスト.txtに記載されたurlから直に作品ページを開けないことへの対策
　※ちょっと場当たり的なコードな気もしますが…

詳細はcommit commentsをご確認ください。
