### PR TITLE
"エラーが発生しました"ページ返却への対応

### DIFF
--- a/source/chrome/content/ankpixiv.js
+++ b/source/chrome/content/ankpixiv.js
@@ -131,8 +131,13 @@ try {
           );
         },
 
-        get largeLink ()
-          AnkPixiv.elements.doc.querySelector('.works_display > a'),
+        get largeLink () {
+          return (
+            AnkPixiv.elements.doc.querySelector('.works_display > a')
+            ||
+            AnkPixiv.elements.doc.querySelector('.works_display > * > a')
+          );
+        },
 
         get worksData ()
           AnkPixiv.elements.doc.querySelector('.work-info'),
@@ -1055,11 +1060,13 @@ try {
         if (AnkPixiv.in.manga) {
           AnkPixiv.getLastMangaPage(function (v, fp, ext) {
             function _download (originalSize) {
-              let urls = [];
-              for (let i = 0; i < v; i++)
-                urls.push(AnkPixiv.info.path.getLargeMangaImage(i, url, ext, originalSize));
-              AnkPixiv.downloadFiles(urls, ref, destFiles.image, fp, onComplete, onError);
-              addDownloading();
+              if (v) {
+                let urls = [];
+                for (let i = 0; i < v; i++)
+                  urls.push(AnkPixiv.info.path.getLargeMangaImage(i, url, ext, originalSize));
+                AnkPixiv.downloadFiles(urls, ref, destFiles.image, fp, onComplete, onError);
+                addDownloading();
+              }
             }
 
             if (AnkPixiv.Prefs.get('downloadOriginalSize', false)) {
@@ -1308,14 +1315,17 @@ try {
                 currentMangaPage = 0;
                 if (lastMangaPage === undefined) {
                   AnkPixiv.getLastMangaPage(function (v) {
-                    lastMangaPage = v;
                     if (v) {
+                      lastMangaPage = v;
                       for (let i = 0; i < v; i++) {
                         let option = doc.createElement('option');
                         option.textContent = (i + 1) + '/' + v;
                         option.value = i;
                         pageSelector.appendChild(option);
                       }
+                    }
+                    else {
+                      changeImageSize();
                     }
                   });
                 }
@@ -1470,6 +1480,10 @@ try {
      *    result:     コールバック関数 function (ページ数)
      */
     getLastMangaPage: function (result) { // {{{
+      
+      if (!AnkPixiv.elements.illust.largeLink.href.match(/mode=manga/))
+        return [1, null];
+
       const PAGE_LIMIT = 50 - 5;
 
       let pagesFromIllustPage = AnkPixiv.info.illust.mangaPages;
@@ -1477,11 +1491,15 @@ try {
       function get (source) {
         const MAX = 1000;
         let doc = AnkUtils.createHTMLDocument(source);
+        if (doc.querySelector('.errorArea')) {
+          window.alert(AnkPixiv.Locale('serverError'));
+          return [0, null];
+        }
         let scripts = AnkUtils.A(doc.querySelectorAll('script'));
-        let sm = scripts.filter(function (e) ~e.textContent.indexOf('pixiv.context.pages'));
-        let fp = new Array(sm.length - 1);
+        let sm = scripts.filter(function (e) ~e.textContent.indexOf('pixiv.context.pages['));
+        let fp = new Array(sm.length);
         sm.forEach(function (v, i, a) {
-          if (v.textContent.match(/pixiv\.context\.images\[(\d+)\]/)) {
+          if (v.textContent.match(/pixiv\.context\.pages\[(\d+)\]/)) {
             fp[i] = 1+parseInt(RegExp.$1);
           }
         });
@@ -1493,7 +1511,7 @@ try {
           // 見開きがない場合
           fp = null;
         }
-        return [Math.min(MAX,sm.length - 1), fp];
+        return [Math.min(MAX,sm.length), fp];
       }
 
       let xhr = new XMLHttpRequest();

--- a/source/chrome/locale/ja-JP/ankpixiv.properties
+++ b/source/chrome/locale/ja-JP/ankpixiv.properties
@@ -11,3 +11,4 @@ largeImageSize.NONE=リサイズしない
 largeImageSize.IN_WINDOW_SIZE=ウィンドウサイズに合わせる
 largeImageSize.IN_WINDOW_HEIGHT=ウィンドウの高さに合わせる
 largeImageSize.IN_WINDOW_WIDTH=ウィンドウの幅に合わせる
+serverError=Pixivがエラーページを返却しました。\nしばらく経ってから再度実行してみてください


### PR DESCRIPTION
マンガページ数の取得時に、Pixivから"エラーが発生しました"ページが返却された場合への対応と、関連するブロックで見つかった他４件の修正を行いました。
詳細はline noteをご確認ください。
検討よろしくお願いします。

★補足★
マンガページ以外に、mediumページで"エラーが発生しました"ページが返却された場合、
installMediumPageFunctionsがtryを繰り返すという現象を確認しています。
そちらは手つかずです、すみません…

あと日本語用のリソースしか作成していません、すみません…
