### PR TITLE
"エラーが発生しました"ページ返却への対応

### DIFF
--- a/source/chrome/locale/ja-JP/ankpixiv.properties
+++ b/source/chrome/locale/ja-JP/ankpixiv.properties
@@ -11,3 +11,4 @@ largeImageSize.NONE=リサイズしない
 largeImageSize.IN_WINDOW_SIZE=ウィンドウサイズに合わせる
 largeImageSize.IN_WINDOW_HEIGHT=ウィンドウの高さに合わせる
 largeImageSize.IN_WINDOW_WIDTH=ウィンドウの幅に合わせる
+serverError=Pixivがエラーページを返却しました。\nしばらく経ってから再度実行してみてください


### PR DESCRIPTION
何回も通知が行ってしまったかと思います、申し訳ありません。

Pixivからサーバエラーが返ってきた場合の対応の件、検討お願いします。

※未処置
・日本語以外のメッセージリソース
・mediumページ自体が"エラーが発生しました"だった場合にinstallMediumPageFunctionsがretry-outするまでループし続ける件
