### PR TITLE
サイトの構成変更によりviewer利用時に画面上部のヘッダが隠れなくなった件の修正

### DIFF
--- a/source/chrome/content/ankpixiv.js
+++ b/source/chrome/content/ankpixiv.js
@@ -175,10 +175,11 @@ try {
           // ヘッダ
           let header1 = AnkUtils.A(AnkPixiv.elements.doc.querySelectorAll('#global-header'));
           let header2 = AnkUtils.A(AnkPixiv.elements.doc.querySelectorAll('.header'));
+          let header3 = AnkUtils.A(AnkPixiv.elements.doc.querySelectorAll('._header'));
 
           let toolbarItems = AnkUtils.A(AnkPixiv.elements.doc.querySelectorAll('#toolbar-items'));
 
-          return ([]).concat(obj, iframe, search, findbox, ldrize, header1, header2, toolbarItems);
+          return ([]).concat(obj, iframe, search, findbox, ldrize, header1, header2, header3, toolbarItems);
         }
       };
 


### PR DESCRIPTION
Pixivの構成変更により、viewerを開いた時に画面上部のヘッダ部分が隠れず
表示した画像の上に居座ってしまうようになったため、対応してみました。

よろしくお願いします。
