### PR TITLE
コメントが二重に表示される

### DIFF
--- a/source/chrome/content/ankpixiv.js
+++ b/source/chrome/content/ankpixiv.js
@@ -1516,7 +1516,7 @@ try {
           } // }}}
 
           // コメント欄を開く
-          if (AnkPixiv.Prefs.get('openComment', false)) // {{{
+          if (AnkPixiv.Prefs.get('openComment', false)  && openComment && openComment.style.display === 'block') // {{{
             setTimeout(function () openComment.click(), 1000);
           // }}}
 


### PR DESCRIPTION
デフォでコメント欄が開くようになった(？)ため、表示されていないので押せないはずの「開く」ボタンをclick()してコメントの１ページ目が二重表示されるようになった問題に対応しました。
