### PR TITLE
外部連携での評価が機能しない

### DIFF
--- a/source/chrome/content/ankpixiv.js
+++ b/source/chrome/content/ankpixiv.js
@@ -2214,8 +2214,7 @@ try {
         throw 'out of range';
       let rating = window.content.window.wrappedJSObject.pixiv.rating;
       if (typeof rating.rate === 'number') {
-        rating.rate = pt;
-        rating.apply.call(rating, {});
+        rating.apply.call(rating, pt);
         if (!AnkPixiv.Prefs.get('downloadWhenRate', false))
           return true;
         let point = AnkPixiv.Prefs.get('downloadRate', 10);


### PR DESCRIPTION
AnkPixiv.rate()で★をつけられなくなったようなので対応しました。
