### PR TITLE
twitterの外部連携画像のDLに失敗することがある不具合の修正

### DIFF
--- a/source/chrome/content/sites/anktwitter.js
+++ b/source/chrome/content/sites/anktwitter.js
@@ -293,7 +293,7 @@ try {
                   let b64dec = window.atob(b64);
                   let index = b64dec.indexOf('http');
                   let lenb = b64dec.substr(0, index);
-                  let len = lenb.charCodeAt(2);
+                  let len = lenb.charCodeAt(lenb.length-1);
                   s = b64dec.substr(index, len);
 
                   AnkUtils.dump('BASE64: '+b64);


### PR DESCRIPTION
twitterの外部連携先情報のbase64文字列をデコードした際に、
URL文字列の長さを表す情報の位置は先頭３バイト目固定と思っていましたが、
そうでないパターンがあり間違っていることが分かったので修正しました。
