### PR TITLE
base64デコードエラーに対する修正

### DIFF
--- a/source/chrome/content/sites/anktwitter.js
+++ b/source/chrome/content/sites/anktwitter.js
@@ -290,7 +290,7 @@ try {
               if (s.match(/\/proxy\.jpg\?.*?t=(.+?)(?:$|&)/)) {
                 try {
                   let b64 = RegExp.$1;
-                  let b64dec = window.atob(b64);
+                  let b64dec = window.atob(b64.replace(/-/g,'+').replace(/_/g,'/'));
                   let index = b64dec.indexOf('http');
                   let lenb = b64dec.substr(0, index);
                   let len = lenb.charCodeAt(lenb.length-1);


### PR DESCRIPTION
素のbase64ではなくbase64url形式だったので、base64に直してからでないと
window.atob()で例外が発生する場合があるので修正しました。

なお前回と同じコードの個所ですが、今日まったく異なるツイートで発覚した問題への対応となります。
連投気味になってしまい申し訳ありません…。
　
