### PR TITLE
nijieで複数画像保存すると2枚目以降がサムネイルになってしまう変更に対応 #125

### DIFF
--- a/source/chrome/content/sites/anknijie.js
+++ b/source/chrome/content/sites/anknijie.js
@@ -424,7 +424,7 @@ Components.utils.import("resource://gre/modules/Task.jsm");
         else {
           AnkUtils.A(self.elements.illust.gallery.querySelectorAll('a > img')).
             forEach(function (v) {
-              m.push(v.src.replace((m.length == 0 ? /\/main\// : /\/small_light.+?\//),'/'));
+              m.push(v.src.replace((m.length == 0 ? /\/main\// : /\/__rs_l120x120\//),'/'));
             });
         }
 


### PR DESCRIPTION
nijieで複数画像保存すると2枚目以降がサムネイルになってしまう変更に対応してみました。
Firefox Developer Edition 54.0a2 で確認しました。
よろしくお願いします。