### PR TITLE
nijie: 複数画像が保存されない問題を修正

### DIFF
--- a/webextensions/source/js/sites/nijie.js
+++ b/webextensions/source/js/sites/nijie.js
@@ -37,7 +37,7 @@
         "med": {
           "img": {"s": "#gallery  > #gallery_open > #img_filter > a > img"},
 
-          "imgs": {"ALL": "#gallery  > #gallery_open > a > img"}
+          "imgs": {"ALL": "#gallery  > #gallery_open > #img_diff > a > img"}
         },
         "djn": {
           "imgLink": {"s": "#dojin_left .left .image a"},


### PR DESCRIPTION
ニジエの複数画像が保存されない現象が確認されたので、SELECTOR_ITEMSを修正しました。
Issue #166 の現象だと思います。
以下の環境で確認しました。

- Firefox Developer Edition 60.0b16
- Ank-Pixiv-Tool 3.0.4
